### PR TITLE
Fix compatibility with Frida v16.5.7 & v16.5.8-dev

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
       id: setup-ndk
       uses: nttld/setup-ndk@v1
       with:
-        ndk-version: r25b
+        ndk-version: r25c
         local-cache: false
         link-to-sdk: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,14 +90,14 @@ jobs:
     if: needs.check_version.outputs.ALREADY_RELEASE != '1'
 
     steps:
-      - uses: actions/create-release@master
+      - uses: softprops/action-gh-release@v2.1.0
         id: createRelease
         name: Create Runner Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: "${{ needs.check_version.outputs.FRIDA_VERSION }}"
-          release_name: "${{ needs.check_version.outputs.FRIDA_VERSION }}"
+          name: "${{ needs.check_version.outputs.FRIDA_VERSION }}"
           prerelease: false
 
   android_build:

--- a/patches/frida-core/0001-Florida-string_frida_rpc.patch
+++ b/patches/frida-core/0001-Florida-string_frida_rpc.patch
@@ -1,4 +1,4 @@
-From d7201c32bd8cf347cacd7427a942e0e0188045a1 Mon Sep 17 00:00:00 2001
+From 9ff24d5b1b81bf5a2fc8ff517bc0caba0e3288e9 Mon Sep 17 00:00:00 2001
 From: Ylarod <me@ylarod.cn>
 Date: Tue, 18 Jul 2023 15:51:29 +0800
 Subject: [PATCH 1/9] Florida: string_frida_rpc
@@ -8,7 +8,7 @@ Subject: [PATCH 1/9] Florida: string_frida_rpc
  1 file changed, 12 insertions(+), 3 deletions(-)
 
 diff --git a/lib/base/rpc.vala b/lib/base/rpc.vala
-index 3695ba8c..664bd19c 100644
+index 8990b70e..d5acfebd 100644
 --- a/lib/base/rpc.vala
 +++ b/lib/base/rpc.vala
 @@ -11,13 +11,22 @@ namespace Frida {
@@ -24,7 +24,7 @@ index 3695ba8c..664bd19c 100644
 +			}
 +		}
 +
- 		public async Json.Node call (string method, Json.Node[] args, Cancellable? cancellable) throws Error, IOError {
+ 		public async Json.Node call (string method, Json.Node[] args, Bytes? data, Cancellable? cancellable) throws Error, IOError {
  			string request_id = Uuid.string_random ();
  
  			var request = new Json.Builder ();
@@ -54,5 +54,5 @@ index 3695ba8c..664bd19c 100644
  
  			var request_id_value = rpc_message.get_element (1);
 -- 
-2.42.0
+2.47.1
 


### PR DESCRIPTION
- Updates the Florida `string_frida_rpc` patch to be compatible with Frida version 15.6.7. The original patch became obsolete due to updates in the Frida codebase, preventing it from being applied successfully. This update resolves the conflicts and ensures the patch functions correctly with the latest version

- Updated the NDK version to `r25c` to align with `frida/frida-core@main`.

- Since `actions/create-release` has not been updated for 3.5 years and is now archived, it has been replaced with `softprops/action-gh-release@v2.1.0`. This change eliminates the warning messages previously generated by the old workflow.