### PR TITLE
Fix symbol_frida_agent_main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -307,7 +307,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: '${{ steps.checkReleaseVersion.outputs.upload_url }}'
-        asset_path: '${{ github.workspace }}/build-android-arm/subprojects/frida-core/lib/gadget/frida-gadget.gz'
+        asset_path: '${{ github.workspace }}/build-android-arm/subprojects/frida-core/lib/gadget/frida-gadget.so.gz'
         asset_name: 'florida-gadget-${{ needs.check_version.outputs.FRIDA_VERSION }}-android-arm.so.gz'
         asset_content_type: application/octet-stream
 
@@ -317,7 +317,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: '${{ steps.checkReleaseVersion.outputs.upload_url }}'
-        asset_path: '${{ github.workspace }}/build-android-arm64/subprojects/frida-core/lib/gadget/frida-gadget.gz'
+        asset_path: '${{ github.workspace }}/build-android-arm64/subprojects/frida-core/lib/gadget/frida-gadget.so.gz'
         asset_name: 'florida-gadget-${{ needs.check_version.outputs.FRIDA_VERSION }}-android-arm64.so.gz'
         asset_content_type: application/octet-stream
    
@@ -327,7 +327,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: '${{ steps.checkReleaseVersion.outputs.upload_url }}'
-        asset_path: '${{ github.workspace }}/build-android-x86/subprojects/frida-core/lib/gadget/frida-gadget.gz'
+        asset_path: '${{ github.workspace }}/build-android-x86/subprojects/frida-core/lib/gadget/frida-gadget.so.gz'
         asset_name: 'florida-gadget-${{ needs.check_version.outputs.FRIDA_VERSION }}-android-x86.so.gz'
         asset_content_type: application/octet-stream
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,6 @@ jobs:
         
         export ANDROID_NDK_ROOT=${{ steps.setup-ndk.outputs.ndk-path }}
         echo "ANDROID_NDK_ROOT=$ANDROID_NDK_ROOT"
-        tree $ANDROID_NDK_ROOT
         
         git clone --recurse-submodules https://github.com/frida/frida
         cd frida

--- a/patches/frida-core/0003-Florida-symbol_frida_agent_main.patch
+++ b/patches/frida-core/0003-Florida-symbol_frida_agent_main.patch
@@ -25,7 +25,7 @@ index 73e0c017..a3db1112 100644
  
  			void * main_func_symbol;
 -			var main_func_found = container.module.symbol ("frida_agent_main", out main_func_symbol);
-+			var main_func_found = container.module.symbol ("frida_agent_main", out main_func_symbol);
++			var main_func_found = container.module.symbol ("main", out main_func_symbol);
  			assert (main_func_found);
  			container.main_impl = (AgentMainFunc) main_func_symbol;
  
@@ -72,7 +72,7 @@ index ab9b2900..4369922d 100644
  			uint id;
  
 -			unowned string entrypoint = "frida_agent_main";
-+			unowned string entrypoint = "frida_agent_main";
++			unowned string entrypoint = "main";
  #if HAVE_EMBEDDED_ASSETS
  			id = yield fruitjector.inject_library_resource (pid, agent, entrypoint, agent_parameters, cancellable);
  #else
@@ -85,7 +85,7 @@ index a2204a4e..eac16116 100644
  			var stream_request = Pipe.open (t.local_address, cancellable);
  
 -			var id = yield binjector.inject_library_resource (pid, agent_desc, "frida_agent_main",
-+			var id = yield binjector.inject_library_resource (pid, agent_desc, "frida_agent_main",
++			var id = yield binjector.inject_library_resource (pid, agent_desc, "main",
  				make_agent_parameters (pid, t.remote_address, options), cancellable);
  			injectee_by_pid[pid] = id;
  
@@ -98,7 +98,7 @@ index 64245792..086d0b96 100644
  				Cancellable? cancellable, out Object? transport) throws Error, IOError {
  			uint id;
 -			string entrypoint = "frida_agent_main";
-+			string entrypoint = "frida_agent_main";
++			string entrypoint = "main";
  			string parameters = make_agent_parameters (pid, "", options);
  			AgentFeatures features = CONTROL_CHANNEL;
  			var linjector = (Linjector) injector;
@@ -111,7 +111,7 @@ index 69f2995f..a4e59ab2 100644
  			var stream_request = Pipe.open (t.local_address, cancellable);
  
 -			var id = yield qinjector.inject_library_resource (pid, agent_desc, "frida_agent_main",
-+			var id = yield qinjector.inject_library_resource (pid, agent_desc, "frida_agent_main",
++			var id = yield qinjector.inject_library_resource (pid, agent_desc, "main",
  				make_agent_parameters (pid, t.remote_address, options), cancellable);
  			injectee_by_pid[pid] = id;
  
@@ -124,7 +124,7 @@ index 67f1f3ef..518cd256 100644
  
  			var winjector = injector as Winjector;
 -			var id = yield winjector.inject_library_resource (pid, agent, "frida_agent_main",
-+			var id = yield winjector.inject_library_resource (pid, agent, "frida_agent_main",
++			var id = yield winjector.inject_library_resource (pid, agent, "main",
  				make_agent_parameters (pid, t.remote_address, options), cancellable);
  			injectee_by_pid[pid] = id;
  
@@ -137,7 +137,7 @@ index d28e67fd..bbdc29b3 100644
  
  			void * main_func_symbol;
 -			var main_func_found = module.symbol ("frida_agent_main", out main_func_symbol);
-+			var main_func_found = module.symbol ("frida_agent_main", out main_func_symbol);
++			var main_func_found = module.symbol ("main", out main_func_symbol);
  			assert_true (main_func_found);
  			main_impl = (AgentMainFunc) main_func_symbol;
  
@@ -150,7 +150,7 @@ index 03c219e6..a7720c3d 100644
  				assert_true (FileUtils.test (path, FileTest.EXISTS));
  
 -				yield injector.inject_library_file (process.id, path, "frida_agent_main", data);
-+				yield injector.inject_library_file (process.id, path, "frida_agent_main", data);
++				yield injector.inject_library_file (process.id, path, "main", data);
  			} catch (GLib.Error e) {
  				printerr ("\nFAIL: %s\n\n", e.message);
  				assert_not_reached ();

--- a/patches/frida-core/0010-exec-anti-anti-frida.py.patch
+++ b/patches/frida-core/0010-exec-anti-anti-frida.py.patch
@@ -1,0 +1,31 @@
+From 09c74884dda5e9a5d452a7d5b78eb1c3e8a717c9 Mon Sep 17 00:00:00 2001
+From: Thiasap <you@example.com>
+Date: Mon, 9 Dec 2024 16:28:59 +0800
+Subject: [PATCH] exec anti-anti-frida.py
+
+---
+ src/embed-agent.py | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/embed-agent.py b/src/embed-agent.py
+index 1cdd46da..4459b9c1 100644
+--- a/src/embed-agent.py
++++ b/src/embed-agent.py
+@@ -78,6 +78,14 @@ def main(argv):
+                 shutil.copy(agent, embedded_agent)
+             else:
+                 embedded_agent.write_bytes(b"")
++            import os
++            custom_script=str(output_dir)+"/../../../../frida/subprojects/frida-core/src/anti-anti-frida.py"
++            return_code = os.system("python3 "+custom_script+" "+str(priv_dir / f"frida-agent-{flavor}.so"))
++            if return_code == 0:
++                print("anti-anti-frida finished")
++            else:
++                print("anti-anti-frida error. Code:", return_code)
++            
+             embedded_assets += [embedded_agent]
+     elif host_os in {"freebsd", "qnx"}:
+         embedded_agent = priv_dir / "frida-agent.so"
+-- 
+2.34.1
+


### PR DESCRIPTION
修改frida_agent_main需要改源码的同时用anti-anti-frida.py去对.so进行修改，某个版本开始，`src/embed-agent.sh`改成了`src/embed-agent.py`，所以编译的时候anti-anti-frida.py不再工作，导致出现了找不到main符号，从那开始florida就把对frida_agent_main的patch取消了，经过测试，在`src/embed-agent.py`合适的位置采用简单粗暴的python脚本执行方式执行anti-anti-frida.py可以完成编译，且可以绕过 一处内存检测。

(Bad English)
Patch frida_agent_main need to modify the code and use anti-anti-frida.py to patch .so. since a certain version, `src/embed-agent.sh` was changed to `src/embed-agent.py`, so anti-anti-frida.py no longer worked during compilation. Causes Not Found Symbol 'main' error. From then on, florida cancelled the patch for frida_agent_main. After testing, it was found that executing anti-anti-frida.py in a simple and crude python script execution method at the appropriate location of` src/embed-agent.py` can complete the compilation and bypass a memory detection.
florida without anti-anti-frida.py：
![flo](https://github.com/user-attachments/assets/efa59217-f09b-4876-8b99-ce506bdf0493)
florida with anti-anti-frida.py：
![flo_anti](https://github.com/user-attachments/assets/2d3159d2-9ab8-43f0-9bf9-0020822eed14)


· 代码能力、git使用能力有限，如有更高效的方案，可以否掉这条pr，提交新的pr。