### PR TITLE
update syscall symbol from 17.7.0 to memfd patch

### DIFF
--- a/patches/frida-core/0009-Florida-memfd-name-jit-cache.patch
+++ b/patches/frida-core/0009-Florida-memfd-name-jit-cache.patch
@@ -15,8 +15,8 @@ index 9da2152c..b133bd37 100644
  		}
  
  		private int memfd_create (string name, uint flags) {
--			return Linux.syscall (SysCall.memfd_create, name, flags);
-+			return Linux.syscall (SysCall.memfd_create, "jit-cache", flags);
+-			return Linux.syscall (LinuxSyscall.MEMFD_CREATE, name, flags);
++			return Linux.syscall (LinuxSyscall.MEMFD_CREATE, "jit-cache", flags);
  		}
  	}
  }


### PR DESCRIPTION
Due to frida/frida-core@9d91e52490eb8e2bf38befc28d2db41fe6d45030